### PR TITLE
uploads json format has changed

### DIFF
--- a/lib/filehandler.js
+++ b/lib/filehandler.js
@@ -8,14 +8,16 @@ module.exports = function (middleware, options) {
         var UploadHandler = require('./uploadhandler')(options);
         var handler = new UploadHandler(req, res, function (result, redirect) {
             if (redirect) {
-                res.redirect(redirect.replace(/%s/, encodeURIComponent(JSON.stringify(result))));
+                files = {files: result};
+                res.redirect(redirect.replace(/%s/, encodeURIComponent(JSON.stringify(files))));
             } else {
                 res.set({
                     'Content-Type': (req.headers.accept || '').indexOf('application/json') !== -1
                         ? 'application/json'
                         : 'text/plain'
                 });
-                res.json(200, result);
+                files = {files: result};
+                res.json(200, files);
             }
         });
 


### PR DESCRIPTION
see:
https://groups.google.com/forum/#!searchin/jquery-fileupload/empty/jquer
y-fileupload/0q8PN2v0I28/pOYs76W-VsEJ

and: https://github.com/blueimp/jQuery-File-Upload/wiki/Setup

format:

{"files": [
  {
    "name": "picture1.jpg",
    "size": 902604,
    "url": "http:\/\/example.org\/files\/picture1.jpg",
    "thumbnail_url":
"http:\/\/example.org\/files\/thumbnail\/picture1.jpg",
    "delete_url": "http:\/\/example.org\/files\/picture1.jpg",
    "delete_type": "DELETE"
  },
  {
    "name": "picture2.jpg",
    "size": 841946,
    "url": "http:\/\/example.org\/files\/picture2.jpg",
    "thumbnail_url":
"http:\/\/example.org\/files\/thumbnail\/picture2.jpg",
    "delete_url": "http:\/\/example.org\/files\/picture2.jpg",
    "delete_type": "DELETE"
  }
]}
