### PR TITLE
Fixed JSON compatibility issue

### DIFF
--- a/lib/filehandler.js
+++ b/lib/filehandler.js
@@ -17,7 +17,7 @@ module.exports = function (middleware, options) {
                         : 'text/plain'
                 });
                 files = {files: result};
-                res.json(200, files);
+                res.json(200, { files: files });
             }
         });
 


### PR DESCRIPTION
The middleware's JSON output is currently not compatible with the format jQuery File Upload expects. Fixed it.

http://github.com/blueimp/jQuery-File-Upload/wiki/JSON-Response
