### PR TITLE
Trying to fix passing formData from form to middleware

### DIFF
--- a/lib/uploadhandler.js
+++ b/lib/uploadhandler.js
@@ -1,184 +1,188 @@
 var EventEmitter = require('events').EventEmitter,
-    path = require('path'),
-    fs = require('fs'),
-    formidable = require('formidable'),
-    imageMagick = require('imagemagick'),
-    mkdirp = require('mkdirp'),
-    _ = require('lodash');
+	path = require('path'),
+	fs = require('fs'),
+	formidable = require('formidable'),
+	imageMagick = require('imagemagick'),
+	mkdirp = require('mkdirp'),
+	_ = require('lodash');
 
 module.exports = function (options) {
 
-    var FileInfo = require('./fileinfo')(
-        _.extend({
-            baseDir: options.uploadDir
-        }, _.pick(options, 'minFileSize', 'maxFileSize', 'acceptFileTypes'))
-    );
+	var FileInfo = require('./fileinfo')(
+		_.extend({
+			baseDir: options.uploadDir
+		}, _.pick(options, 'minFileSize', 'maxFileSize', 'acceptFileTypes'))
+	);
 
-    var UploadHandler = function (req, res, callback) {
-        EventEmitter.call(this);
-        this.req = req;
-        this.res = res;
-        this.callback = callback;
-    };
-    require('util').inherits(UploadHandler, EventEmitter);
+	var UploadHandler = function (req, res, callback) {
+		EventEmitter.call(this);
+		this.req = req;
+		this.res = res;
+		this.callback = callback;
+	};
+	require('util').inherits(UploadHandler, EventEmitter);
 
-    UploadHandler.prototype.noCache = function () {
-        this.res.set({
-            'Pragma': 'no-cache',
-            'Cache-Control': 'no-store, no-cache, must-revalidate',
-            'Content-Disposition': 'inline; filename="files.json"'
-        });
-    };
+	UploadHandler.prototype.noCache = function () {
+		this.res.set({
+			'Pragma': 'no-cache',
+			'Cache-Control': 'no-store, no-cache, must-revalidate',
+			'Content-Disposition': 'inline; filename="files.json"'
+		});
+	};
 
-    UploadHandler.prototype.get = function () {
-        this.noCache();
-        var files = [];
-        fs.readdir(options.uploadDir(), _.bind(function (err, list) {
-            _.each(list, function (name) {
-                var stats = fs.statSync(options.uploadDir() + '/' + name),
-                    fileInfo;
-                if (stats.isFile()) {
-                    fileInfo = new FileInfo({
-                        name: name,
-                        size: stats.size
-                    });
-                    this.initUrls(fileInfo);
-                    files.push(fileInfo);
-                }
-            }, this);
-            this.callback({files: files});
-        }, this));
-    };
+	UploadHandler.prototype.get = function () {
+		this.noCache();
+		var files = [];
+		fs.readdir(options.uploadDir(), _.bind(function (err, list) {
+			_.each(list, function (name) {
+				var stats = fs.statSync(options.uploadDir() + '/' + name),
+					fileInfo;
+				if (stats.isFile()) {
+					fileInfo = new FileInfo({
+						name: name,
+						size: stats.size
+					});
+					this.initUrls(fileInfo);
+					files.push(fileInfo);
+				}
+			}, this);
+			this.callback({files: files});
+		}, this));
+	};
 
-    UploadHandler.prototype.post = function () {
-        var self = this,
-            form = new formidable.IncomingForm(),
-            tmpFiles = [],
-            files = [],
-            map = {},
-            counter = 1,
-            redirect,
-            finish = _.bind(function () {
-                if (!--counter) {
-                    _.each(files, function (fileInfo) {
-                        this.initUrls(fileInfo);
-                        this.emit('end', fileInfo);
-                    }, this);
-                    this.callback({files: files}, redirect);
-                }
-            }, this);
+	UploadHandler.prototype.post = function () {
+		var self = this,
+			form = new formidable.IncomingForm(),
+			tmpFiles = [],
+			files = [],
+			map = {},
+			counter = 1,
+			redirect,
+			finish = _.bind(function () {
+				if (!--counter) {
+					_.each(files, function (fileInfo) {
+						this.initUrls(fileInfo);
+						fileInfo = _.extend(fileInfo, self.req.fields);
+						this.emit('end', fileInfo);
+					}, this);
+					this.callback({files: files}, redirect);
+				}
+			}, this);
 
-        this.noCache();
+		this.noCache();
 
-        form.uploadDir = options.tmpDir;
-        form
-            .on('fileBegin', function (name, file) {
-                tmpFiles.push(file.path);
-                var fileInfo = new FileInfo(file);
-                fileInfo.safeName();
-                map[path.basename(file.path)] = fileInfo;
-                files.push(fileInfo);
-                self.emit('begin', fileInfo);
-            })
-            .on('field', function (name, value) {
-                if (name === 'redirect') {
-                    redirect = value;
-                }
-            })
-            .on('file', function (name, file) {
-                var fileInfo = map[path.basename(file.path)];
-                if (fs.existsSync(file.path)) {
-                    fileInfo.size = file.size;
-                    if (!fileInfo.validate()) {
-                        fs.unlink(file.path);
-                        return;
-                    }
+		form.uploadDir = options.tmpDir;
+		form
+			.on('fileBegin', function (name, file) {
+				tmpFiles.push(file.path);
+				var fileInfo = new FileInfo(file);
+				fileInfo.safeName();
+				map[path.basename(file.path)] = fileInfo;
+				files.push(fileInfo);
+				self.emit('begin', fileInfo);
+			})
+			.on('field', function (name, value) {
+				if (name === 'redirect') {
+					redirect = value;
+				}
+				if ( !self.req.fields )
+					self.req.fields = {};
+				self.req.fields[name] = value;
+			})
+			.on('file', function (name, file) {
+				var fileInfo = map[path.basename(file.path)];
+				if (fs.existsSync(file.path)) {
+					fileInfo.size = file.size;
+					if (!fileInfo.validate()) {
+						fs.unlink(file.path);
+						return;
+					}
 
-                    var generatePreviews = function () {
-                        if (options.imageTypes.test(fileInfo.name)) {
-                            _.each(options.imageVersions, function (value, version) {
-                                // creating directory recursive
-                                if (!fs.existsSync(options.uploadDir() + '/' + version + '/'))
-                                    mkdirp.sync(options.uploadDir() + '/' + version + '/');
+					var generatePreviews = function () {
+						if (options.imageTypes.test(fileInfo.name)) {
+							_.each(options.imageVersions, function (value, version) {
+								// creating directory recursive
+								if (!fs.existsSync(options.uploadDir() + '/' + version + '/'))
+									mkdirp.sync(options.uploadDir() + '/' + version + '/');
 
-                                counter++;
-                                var opts = options.imageVersions[version];
-                                imageMagick.resize({
-                                    width: opts.width,
-                                    height: opts.height,
-                                    srcPath: options.uploadDir() + '/' + fileInfo.name,
-                                    dstPath: options.uploadDir() + '/' + version + '/' + fileInfo.name,
-                                    customArgs: opts.imageArgs || ['-auto-orient']
-                                }, finish);
-                            });
-                        }
-                    }
+								counter++;
+								var opts = options.imageVersions[version];
+								imageMagick.resize({
+									width: opts.width,
+									height: opts.height,
+									srcPath: options.uploadDir() + '/' + fileInfo.name,
+									dstPath: options.uploadDir() + '/' + version + '/' + fileInfo.name,
+									customArgs: opts.imageArgs || ['-auto-orient']
+								}, finish);
+							});
+						}
+					}
 
-                    if (!fs.existsSync(options.uploadDir() + '/'))
-                        mkdirp.sync(options.uploadDir() + '/');
+					if (!fs.existsSync(options.uploadDir() + '/'))
+						mkdirp.sync(options.uploadDir() + '/');
 
-                    counter++;
-                    fs.rename(file.path, options.uploadDir() + '/' + fileInfo.name, function (err) {
-                        if (!err) {
-                            generatePreviews();
-                            finish();
-                        } else {
-                            var is = fs.createReadStream(file.path);
-                            var os = fs.createWriteStream(options.uploadDir() + '/' + fileInfo.name);
-                            is.on('end', function (err) {
-                                if (!err) {
-                                    fs.unlinkSync(file.path);
-                                    generatePreviews();
-                                }
-                                finish();
-                            });
-                            is.pipe(os);
-                        }
-                    });
-                }
-            })
-            .on('aborted', function () {
-                _.each(tmpFiles, function (file) {
-                    var fileInfo = map[path.basename(file)];
-                    self.emit('abort', fileInfo);
-                    fs.unlink(file);
-                });
-            })
-            .on('error', function (e) {
-                self.emit('error', e);
-            })
-            .on('progress', function (bytesReceived, bytesExpected) {
-                if (bytesReceived > options.maxPostSize)
-                    self.req.connection.destroy();
-            })
-            .on('end', finish)
-            .parse(self.req);
-    };
+					counter++;
+					fs.rename(file.path, options.uploadDir() + '/' + fileInfo.name, function (err) {
+						if (!err) {
+							generatePreviews();
+							finish();
+						} else {
+							var is = fs.createReadStream(file.path);
+							var os = fs.createWriteStream(options.uploadDir() + '/' + fileInfo.name);
+							is.on('end', function (err) {
+								if (!err) {
+									fs.unlinkSync(file.path);
+									generatePreviews();
+								}
+								finish();
+							});
+							is.pipe(os);
+						}
+					});
+				}
+			})
+			.on('aborted', function () {
+				_.each(tmpFiles, function (file) {
+					var fileInfo = map[path.basename(file)];
+					self.emit('abort', fileInfo);
+					fs.unlink(file);
+				});
+			})
+			.on('error', function (e) {
+				self.emit('error', e);
+			})
+			.on('progress', function (bytesReceived, bytesExpected) {
+				if (bytesReceived > options.maxPostSize)
+					self.req.connection.destroy();
+			})
+			.on('end', finish)
+			.parse(self.req);
+	};
 
-    UploadHandler.prototype.destroy = function () {
-        var self = this,
-            fileName = path.basename(decodeURIComponent(this.req.url));
+	UploadHandler.prototype.destroy = function () {
+		var self = this,
+			fileName = path.basename(decodeURIComponent(this.req.url));
 
-        fs.unlink(options.uploadDir() + '/' + fileName, function (ex) {
-            _.each(options.imageVersions, function (value, version) {
-                fs.unlink(options.uploadDir() + '/' + version + '/' + fileName);
-            });
-            self.emit('delete', fileName);
-            self.callback({success: !ex});
-        });
-    };
+		fs.unlink(options.uploadDir() + '/' + fileName, function (ex) {
+			_.each(options.imageVersions, function (value, version) {
+				fs.unlink(options.uploadDir() + '/' + version + '/' + fileName);
+			});
+			self.emit('delete', fileName);
+			self.callback({success: !ex});
+		});
+	};
 
-    UploadHandler.prototype.initUrls = function (fileInfo) {
-        var baseUrl = (options.ssl ? 'https:' : 'http:') + '//' + (options.hostname || this.req.get('Host'));
-        fileInfo.setUrl(null, baseUrl + options.uploadUrl());
-        fileInfo.setUrl('delete', baseUrl + this.req.originalUrl);
-        _.each(options.imageVersions, function (value, version) {
-            if (fs.existsSync(options.uploadDir() + '/' + version + '/' + fileInfo.name)) {
-                fileInfo.setUrl(version, baseUrl + options.uploadUrl() + '/' + version);
-            }
-        }, this);
-    };
+	UploadHandler.prototype.initUrls = function (fileInfo) {
+		var baseUrl = (options.ssl ? 'https:' : 'http:') + '//' + (options.hostname || this.req.get('Host'));
+		fileInfo.setUrl(null, baseUrl + options.uploadUrl());
+		fileInfo.setUrl('delete', baseUrl + this.req.originalUrl);
+		_.each(options.imageVersions, function (value, version) {
+			if (fs.existsSync(options.uploadDir() + '/' + version + '/' + fileInfo.name)) {
+				fileInfo.setUrl(version, baseUrl + options.uploadUrl() + '/' + version);
+			}
+		}, this);
+	};
 
-    return UploadHandler;
+	return UploadHandler;
 }
 

--- a/lib/uploadhandler.js
+++ b/lib/uploadhandler.js
@@ -1,188 +1,188 @@
 var EventEmitter = require('events').EventEmitter,
-	path = require('path'),
-	fs = require('fs'),
-	formidable = require('formidable'),
-	imageMagick = require('imagemagick'),
-	mkdirp = require('mkdirp'),
-	_ = require('lodash');
+    path = require('path'),
+    fs = require('fs'),
+    formidable = require('formidable'),
+    imageMagick = require('imagemagick'),
+    mkdirp = require('mkdirp'),
+    _ = require('lodash');
 
 module.exports = function (options) {
 
-	var FileInfo = require('./fileinfo')(
-		_.extend({
-			baseDir: options.uploadDir
-		}, _.pick(options, 'minFileSize', 'maxFileSize', 'acceptFileTypes'))
-	);
+    var FileInfo = require('./fileinfo')(
+        _.extend({
+            baseDir: options.uploadDir
+        }, _.pick(options, 'minFileSize', 'maxFileSize', 'acceptFileTypes'))
+    );
 
-	var UploadHandler = function (req, res, callback) {
-		EventEmitter.call(this);
-		this.req = req;
-		this.res = res;
-		this.callback = callback;
-	};
-	require('util').inherits(UploadHandler, EventEmitter);
+    var UploadHandler = function (req, res, callback) {
+        EventEmitter.call(this);
+        this.req = req;
+        this.res = res;
+        this.callback = callback;
+    };
+    require('util').inherits(UploadHandler, EventEmitter);
 
-	UploadHandler.prototype.noCache = function () {
-		this.res.set({
-			'Pragma': 'no-cache',
-			'Cache-Control': 'no-store, no-cache, must-revalidate',
-			'Content-Disposition': 'inline; filename="files.json"'
-		});
-	};
+    UploadHandler.prototype.noCache = function () {
+        this.res.set({
+            'Pragma': 'no-cache',
+            'Cache-Control': 'no-store, no-cache, must-revalidate',
+            'Content-Disposition': 'inline; filename="files.json"'
+        });
+    };
 
-	UploadHandler.prototype.get = function () {
-		this.noCache();
-		var files = [];
-		fs.readdir(options.uploadDir(), _.bind(function (err, list) {
-			_.each(list, function (name) {
-				var stats = fs.statSync(options.uploadDir() + '/' + name),
-					fileInfo;
-				if (stats.isFile()) {
-					fileInfo = new FileInfo({
-						name: name,
-						size: stats.size
-					});
-					this.initUrls(fileInfo);
-					files.push(fileInfo);
-				}
-			}, this);
-			this.callback({files: files});
-		}, this));
-	};
+    UploadHandler.prototype.get = function () {
+        this.noCache();
+        var files = [];
+        fs.readdir(options.uploadDir(), _.bind(function (err, list) {
+            _.each(list, function (name) {
+                var stats = fs.statSync(options.uploadDir() + '/' + name),
+                    fileInfo;
+                if (stats.isFile()) {
+                    fileInfo = new FileInfo({
+                        name: name,
+                        size: stats.size
+                    });
+                    this.initUrls(fileInfo);
+                    files.push(fileInfo);
+                }
+            }, this);
+            this.callback({files: files});
+        }, this));
+    };
 
-	UploadHandler.prototype.post = function () {
-		var self = this,
-			form = new formidable.IncomingForm(),
-			tmpFiles = [],
-			files = [],
-			map = {},
-			counter = 1,
-			redirect,
-			finish = _.bind(function () {
-				if (!--counter) {
-					_.each(files, function (fileInfo) {
-						this.initUrls(fileInfo);
-						fileInfo = _.extend(fileInfo, self.req.fields);
-						this.emit('end', fileInfo);
-					}, this);
-					this.callback({files: files}, redirect);
-				}
-			}, this);
+    UploadHandler.prototype.post = function () {
+        var self = this,
+            form = new formidable.IncomingForm(),
+            tmpFiles = [],
+            files = [],
+            map = {},
+            counter = 1,
+            redirect,
+            finish = _.bind(function () {
+                if (!--counter) {
+                    _.each(files, function (fileInfo) {
+                        this.initUrls(fileInfo);
+                        fileInfo = _.extend(fileInfo, self.req.fields);
+                        this.emit('end', fileInfo);
+                    }, this);
+                    this.callback({files: files}, redirect);
+                }
+            }, this);
 
-		this.noCache();
+        this.noCache();
 
-		form.uploadDir = options.tmpDir;
-		form
-			.on('fileBegin', function (name, file) {
-				tmpFiles.push(file.path);
-				var fileInfo = new FileInfo(file);
-				fileInfo.safeName();
-				map[path.basename(file.path)] = fileInfo;
-				files.push(fileInfo);
-				self.emit('begin', fileInfo);
-			})
-			.on('field', function (name, value) {
-				if (name === 'redirect') {
-					redirect = value;
-				}
-				if ( !self.req.fields )
-					self.req.fields = {};
-				self.req.fields[name] = value;
-			})
-			.on('file', function (name, file) {
-				var fileInfo = map[path.basename(file.path)];
-				if (fs.existsSync(file.path)) {
-					fileInfo.size = file.size;
-					if (!fileInfo.validate()) {
-						fs.unlink(file.path);
-						return;
-					}
+        form.uploadDir = options.tmpDir;
+        form
+            .on('fileBegin', function (name, file) {
+                tmpFiles.push(file.path);
+                var fileInfo = new FileInfo(file);
+                fileInfo.safeName();
+                map[path.basename(file.path)] = fileInfo;
+                files.push(fileInfo);
+                self.emit('begin', fileInfo);
+            })
+            .on('field', function (name, value) {
+                if (name === 'redirect') {
+                    redirect = value;
+                }
+                if ( !self.req.fields )
+                    self.req.fields = {};
+                self.req.fields[name] = value;
+            })
+            .on('file', function (name, file) {
+                var fileInfo = map[path.basename(file.path)];
+                if (fs.existsSync(file.path)) {
+                    fileInfo.size = file.size;
+                    if (!fileInfo.validate()) {
+                        fs.unlink(file.path);
+                        return;
+                    }
 
-					var generatePreviews = function () {
-						if (options.imageTypes.test(fileInfo.name)) {
-							_.each(options.imageVersions, function (value, version) {
-								// creating directory recursive
-								if (!fs.existsSync(options.uploadDir() + '/' + version + '/'))
-									mkdirp.sync(options.uploadDir() + '/' + version + '/');
+                    var generatePreviews = function () {
+                        if (options.imageTypes.test(fileInfo.name)) {
+                            _.each(options.imageVersions, function (value, version) {
+                                // creating directory recursive
+                                if (!fs.existsSync(options.uploadDir() + '/' + version + '/'))
+                                    mkdirp.sync(options.uploadDir() + '/' + version + '/');
 
-								counter++;
-								var opts = options.imageVersions[version];
-								imageMagick.resize({
-									width: opts.width,
-									height: opts.height,
-									srcPath: options.uploadDir() + '/' + fileInfo.name,
-									dstPath: options.uploadDir() + '/' + version + '/' + fileInfo.name,
-									customArgs: opts.imageArgs || ['-auto-orient']
-								}, finish);
-							});
-						}
-					}
+                                counter++;
+                                var opts = options.imageVersions[version];
+                                imageMagick.resize({
+                                    width: opts.width,
+                                    height: opts.height,
+                                    srcPath: options.uploadDir() + '/' + fileInfo.name,
+                                    dstPath: options.uploadDir() + '/' + version + '/' + fileInfo.name,
+                                    customArgs: opts.imageArgs || ['-auto-orient']
+                                }, finish);
+                            });
+                        }
+                    }
 
-					if (!fs.existsSync(options.uploadDir() + '/'))
-						mkdirp.sync(options.uploadDir() + '/');
+                    if (!fs.existsSync(options.uploadDir() + '/'))
+                        mkdirp.sync(options.uploadDir() + '/');
 
-					counter++;
-					fs.rename(file.path, options.uploadDir() + '/' + fileInfo.name, function (err) {
-						if (!err) {
-							generatePreviews();
-							finish();
-						} else {
-							var is = fs.createReadStream(file.path);
-							var os = fs.createWriteStream(options.uploadDir() + '/' + fileInfo.name);
-							is.on('end', function (err) {
-								if (!err) {
-									fs.unlinkSync(file.path);
-									generatePreviews();
-								}
-								finish();
-							});
-							is.pipe(os);
-						}
-					});
-				}
-			})
-			.on('aborted', function () {
-				_.each(tmpFiles, function (file) {
-					var fileInfo = map[path.basename(file)];
-					self.emit('abort', fileInfo);
-					fs.unlink(file);
-				});
-			})
-			.on('error', function (e) {
-				self.emit('error', e);
-			})
-			.on('progress', function (bytesReceived, bytesExpected) {
-				if (bytesReceived > options.maxPostSize)
-					self.req.connection.destroy();
-			})
-			.on('end', finish)
-			.parse(self.req);
-	};
+                    counter++;
+                    fs.rename(file.path, options.uploadDir() + '/' + fileInfo.name, function (err) {
+                        if (!err) {
+                            generatePreviews();
+                            finish();
+                        } else {
+                            var is = fs.createReadStream(file.path);
+                            var os = fs.createWriteStream(options.uploadDir() + '/' + fileInfo.name);
+                            is.on('end', function (err) {
+                                if (!err) {
+                                    fs.unlinkSync(file.path);
+                                    generatePreviews();
+                                }
+                                finish();
+                            });
+                            is.pipe(os);
+                        }
+                    });
+                }
+            })
+            .on('aborted', function () {
+                _.each(tmpFiles, function (file) {
+                    var fileInfo = map[path.basename(file)];
+                    self.emit('abort', fileInfo);
+                    fs.unlink(file);
+                });
+            })
+            .on('error', function (e) {
+                self.emit('error', e);
+            })
+            .on('progress', function (bytesReceived, bytesExpected) {
+                if (bytesReceived > options.maxPostSize)
+                    self.req.connection.destroy();
+            })
+            .on('end', finish)
+            .parse(self.req);
+    };
 
-	UploadHandler.prototype.destroy = function () {
-		var self = this,
-			fileName = path.basename(decodeURIComponent(this.req.url));
+    UploadHandler.prototype.destroy = function () {
+        var self = this,
+            fileName = path.basename(decodeURIComponent(this.req.url));
 
-		fs.unlink(options.uploadDir() + '/' + fileName, function (ex) {
-			_.each(options.imageVersions, function (value, version) {
-				fs.unlink(options.uploadDir() + '/' + version + '/' + fileName);
-			});
-			self.emit('delete', fileName);
-			self.callback({success: !ex});
-		});
-	};
+        fs.unlink(options.uploadDir() + '/' + fileName, function (ex) {
+            _.each(options.imageVersions, function (value, version) {
+                fs.unlink(options.uploadDir() + '/' + version + '/' + fileName);
+            });
+            self.emit('delete', fileName);
+            self.callback({success: !ex});
+        });
+    };
 
-	UploadHandler.prototype.initUrls = function (fileInfo) {
-		var baseUrl = (options.ssl ? 'https:' : 'http:') + '//' + (options.hostname || this.req.get('Host'));
-		fileInfo.setUrl(null, baseUrl + options.uploadUrl());
-		fileInfo.setUrl('delete', baseUrl + this.req.originalUrl);
-		_.each(options.imageVersions, function (value, version) {
-			if (fs.existsSync(options.uploadDir() + '/' + version + '/' + fileInfo.name)) {
-				fileInfo.setUrl(version, baseUrl + options.uploadUrl() + '/' + version);
-			}
-		}, this);
-	};
+    UploadHandler.prototype.initUrls = function (fileInfo) {
+        var baseUrl = (options.ssl ? 'https:' : 'http:') + '//' + (options.hostname || this.req.get('Host'));
+        fileInfo.setUrl(null, baseUrl + options.uploadUrl());
+        fileInfo.setUrl('delete', baseUrl + this.req.originalUrl);
+        _.each(options.imageVersions, function (value, version) {
+            if (fs.existsSync(options.uploadDir() + '/' + version + '/' + fileInfo.name)) {
+                fileInfo.setUrl(version, baseUrl + options.uploadUrl() + '/' + version);
+            }
+        }, this);
+    };
 
-	return UploadHandler;
+    return UploadHandler;
 }
 


### PR DESCRIPTION
I needed to use 'formData' sent from the client and since the middleware isn't collecting it properly, I tried to make a fix.

This what I did:
Collect formData on 'field' formidable event in UploadHandler.prototype.post method to a req.fields object (created new object if undefined). Extend fileInfo with req.fields on 'end' event. So on upload.on("end", function (fileInfo)), I can have the extra property from formData in fileInfo.

Example use:

In the client:

``` html
<form id="formupload" action="/temp" method="post" enctype="multipart/form-data">
    <input type="hidden" name="user_id" value="some user id">
    <input id="fileupload" type="file" name="files[]" data-url="/temp" multiple>
</form>
```

In the server:

``` javascript
upload.on("end", function (fileInfo)
    {
        var filemanager = upload.fileManager({
            targetDir: __dirname + "/public/userfiles/" + fileInfo.user_id,
            targetUrl: "/userfiles/" + fileInfo.user_id
        });
        filemanager.move(fileInfo.name, "", function (err, result)
        {
            console.dir(result);
        })
    });
```
