### PR TITLE
Add path option to return uploaded file path

### DIFF
--- a/lib/fileinfo.js
+++ b/lib/fileinfo.js
@@ -38,5 +38,9 @@ module.exports = function (options) {
         this[key] = baseUrl + '/' + encodeURIComponent(this.name);
     }
 
+	FileInfo.prototype.setPath = function (type, data) {
+		this[type] = data + '/' + encodeURIComponent(this.name);
+	}
+
     return FileInfo;
 };

--- a/lib/uploadhandler.js
+++ b/lib/uploadhandler.js
@@ -172,6 +172,7 @@ module.exports = function (options) {
         var baseUrl = (options.ssl ? 'https:' : 'http:') + '//' + (options.hostname || this.req.get('Host'));
         fileInfo.setUrl(null, baseUrl + options.uploadUrl());
         fileInfo.setUrl('delete', baseUrl + this.req.originalUrl);
+		fileInfo.setPath('path', options.uploadUrl());
         _.each(options.imageVersions, function (value, version) {
             if (fs.existsSync(options.uploadDir() + '/' + version + '/' + fileInfo.name)) {
                 fileInfo.setUrl(version, baseUrl + options.uploadUrl() + '/' + version);


### PR DESCRIPTION
Returning the file upload path, usage sample:

app.use('/api/upload', upload.fileHandler({
  uploadDir: __dirname + '/../public/uploads/'+moment().format('YYYY[/]MM'),
  uploadUrl: '/uploads/'+moment().format('YYYY[/]MM'),
  path: __dirname + '/../public/uploads/'+moment().format('YYYY[/]MM')
}));
