### PR TITLE
Gracefully handle error when uploadDir path is inside a file

### DIFF
--- a/lib/uploadhandler.js
+++ b/lib/uploadhandler.js
@@ -142,6 +142,13 @@ module.exports = function (options) {
                                     generatePreviews();
                                     finish();
                                 } else {
+                                    if (err.code === 'ENOTDIR') {
+                                        // Tried to rename to a path inside a file
+                                        fs.unlink(file.path);
+                                        self.emit('error', err);
+                                        return;
+                                    }
+
                                     var is = fs.createReadStream(file.path);
                                     var os = fs.createWriteStream(options.uploadDir() + '/' + fileInfo.name);
                                     is.on('end', function (err) {


### PR DESCRIPTION
If I have file `/upload/a` and `uploadDir` is a function that returns `/upload/a/b`, an unhandled error occurs. This PR checks for that error.