### PR TITLE
Fixed Express deprecation warning on filehandler.js

### DIFF
--- a/lib/filehandler.js
+++ b/lib/filehandler.js
@@ -16,7 +16,7 @@ module.exports = function (middleware, options) {
                         ? 'application/json'
                         : 'text/plain'
                 });
-                res.json(200, result);
+                res.status(200).json(result);
             }
         });
 


### PR DESCRIPTION
express deprecated res.json(status, obj): Use res.status(status).json(obj) instead node_modules/jquery-file-upload-middleware/lib/filehandler.js:19:21