### PR TITLE
Fixed Express deprecation warning on uploadhandler.js

### DIFF
--- a/lib/uploadhandler.js
+++ b/lib/uploadhandler.js
@@ -108,62 +108,60 @@ module.exports = function (options) {
             .on('file', function (name, file) {
                 counter++;
                 var fileInfo = map[path.basename(file.path)];
-                fs.exists(file.path, function(exists) {
-                    if (exists) {
-                        fileInfo.size = file.size;
-                        if (!fileInfo.validate()) {
-                            fs.unlink(file.path);
-                            finish();
-                            return;
-                        }
-
-                        var generatePreviews = function () {
-                            if (options.imageTypes.test(fileInfo.name)) {
-                                _.each(options.imageVersions, function (value, version) {
-                                    counter++;
-                                    // creating directory recursive
-                                    mkdirp(options.uploadDir() + '/' + version + '/', function (err, made) {
-                                        var opts = options.imageVersions[version];
-                                        imageMagick.resize({
-                                            width: opts.width,
-                                            height: opts.height,
-                                            srcPath: options.uploadDir() + '/' + fileInfo.name,
-                                            dstPath: options.uploadDir() + '/' + version + '/' + fileInfo.name,
-                                            customArgs: opts.imageArgs || ['-auto-orient']
-                                        }, finish);
-                                    });
-                                });
-                            }
-                        }
-
-                        mkdirp(options.uploadDir() + '/', function(err, made) {
-                            fs.rename(file.path, options.uploadDir() + '/' + fileInfo.name, function (err) {
-                                if (!err) {
-                                    generatePreviews();
-                                    finish();
-                                } else {
-                                    var is = fs.createReadStream(file.path);
-                                    var os = fs.createWriteStream(options.uploadDir() + '/' + fileInfo.name);
-                                    is.on('end', function (err) {
-                                        if (!err) {
-                                            fs.unlink(file.path);
-                                            generatePreviews();
-                                        }
-                                        finish();
-                                    });
-                                    is.pipe(os);
-                                }
-                            });
-                        });
+                if (fs.existsSync(file.path)) {
+                    fileInfo.size = file.size;
+                    if (!fileInfo.validate()) {
+                        fs.unlinkSync(file.path);
+                        finish();
+                        return;
                     }
-                    else finish();
-                });
+
+                    var generatePreviews = function () {
+                        if (options.imageTypes.test(fileInfo.name)) {
+                            _.each(options.imageVersions, function (value, version) {
+                                counter++;
+                                // creating directory recursive
+                                mkdirp(options.uploadDir() + '/' + version + '/', function (err, made) {
+                                    var opts = options.imageVersions[version];
+                                    imageMagick.resize({
+                                        width: opts.width,
+                                        height: opts.height,
+                                        srcPath: options.uploadDir() + '/' + fileInfo.name,
+                                        dstPath: options.uploadDir() + '/' + version + '/' + fileInfo.name,
+                                        customArgs: opts.imageArgs || ['-auto-orient']
+                                    }, finish);
+                                });
+                            });
+                        }
+                    }
+
+                    mkdirp(options.uploadDir() + '/', function(err, made) {
+                        fs.rename(file.path, options.uploadDir() + '/' + fileInfo.name, function (err) {
+                            if (!err) {
+                                generatePreviews();
+                                finish();
+                            } else {
+                                var is = fs.createReadStream(file.path);
+                                var os = fs.createWriteStream(options.uploadDir() + '/' + fileInfo.name);
+                                is.on('end', function (err) {
+                                    if (!err) {
+                                        fs.unlinkSync(file.path);
+                                        generatePreviews();
+                                    }
+                                    finish();
+                                });
+                                is.pipe(os);
+                            }
+                        });
+                    });
+                }
+                else finish();
             })
             .on('aborted', function () {
                 _.each(tmpFiles, function (file) {
                     var fileInfo = map[path.basename(file)];
                     self.emit('abort', fileInfo);
-                    fs.unlink(file);
+                    fs.unlinkSync(file);
                 });
             })
             .on('error', function (e) {
@@ -189,7 +187,7 @@ module.exports = function (options) {
         }
         fs.unlink(filepath, function (ex) {
             _.each(options.imageVersions, function (value, version) {
-                fs.unlink(path.join(options.uploadDir(), version, fileName));
+                fs.unlinkSync(path.join(options.uploadDir(), version, fileName));
             });
             self.emit('delete', fileName);
             self.callback({success: !ex});
@@ -201,10 +199,10 @@ module.exports = function (options) {
         fileInfo.setUrl(null, baseUrl + options.uploadUrl());
         fileInfo.setUrl('delete', baseUrl + this.req.originalUrl);
         async.each(Object.keys(options.imageVersions), function(version, cb) {
-            fs.exists(options.uploadDir() + '/' + version + '/' + fileInfo.name, function(exists) {
-                if (exists) fileInfo.setUrl(version, baseUrl + options.uploadUrl() + '/' + version);
-                cb(null);
-            })
+            if (fs.existsSync(options.uploadDir() + '/' + version + '/' + fileInfo.name)) {
+                fileInfo.setUrl(version, baseUrl + options.uploadUrl() + '/' + version);
+            }
+            cb(null);
         },
         cb);
     };


### PR DESCRIPTION
express deprecated fs.exists(path, callback): Use fs.existsSync(path) instead.
express deprecated fs.unlink(path): Use fs.unlinkSync(path) instead.