### PR TITLE
Fix for `acceptFileTypes` option

### DIFF
--- a/lib/uploadhandler.js
+++ b/lib/uploadhandler.js
@@ -112,8 +112,9 @@ module.exports = function (options) {
                     if (exists) {
                         fileInfo.size = file.size;
                         if (!fileInfo.validate()) {
-                            fs.unlink(file.path);
-                            finish();
+                            fs.unlink(file.path, function() {
+                                finish();
+                            });
                             return;
                         }
 


### PR DESCRIPTION
Getting this error in node 10.5.0 when I specify the `acceptFileTypes` option and the uploaded file does not pass.

```
TypeError [ERR_INVALID_CALLBACK]: Callback must be a function
{snip}node_modules/jquery-file-upload-middleware/lib/uploadhandler.js:115:32
```

This PR fixes that issue.