### PR TITLE
fix:Callback must be a function when use fs.unlink in node.js v7.0+

### DIFF
--- a/lib/uploadhandler.js
+++ b/lib/uploadhandler.js
@@ -112,7 +112,7 @@ module.exports = function (options) {
                     if (exists) {
                         fileInfo.size = file.size;
                         if (!fileInfo.validate()) {
-                            fs.unlink(file.path);
+                            fs.unlink(file.path,function(){});
                             finish();
                             return;
                         }
@@ -146,7 +146,7 @@ module.exports = function (options) {
                                     var os = fs.createWriteStream(options.uploadDir() + '/' + fileInfo.name);
                                     is.on('end', function (err) {
                                         if (!err) {
-                                            fs.unlink(file.path);
+                                            fs.unlink(file.path,function(){});
                                             generatePreviews();
                                         }
                                         finish();
@@ -163,7 +163,7 @@ module.exports = function (options) {
                 _.each(tmpFiles, function (file) {
                     var fileInfo = map[path.basename(file)];
                     self.emit('abort', fileInfo);
-                    fs.unlink(file);
+                    fs.unlink(file,function(){});
                 });
             })
             .on('error', function (e) {
@@ -189,7 +189,7 @@ module.exports = function (options) {
         }
         fs.unlink(filepath, function (ex) {
             _.each(options.imageVersions, function (value, version) {
-                fs.unlink(path.join(options.uploadDir(), version, fileName));
+                fs.unlink(path.join(options.uploadDir(), version, fileName),function(){});
             });
             self.emit('delete', fileName);
             self.callback({success: !ex});


### PR DESCRIPTION
Since node v7.0.0, when use fs.unlink(path, callback) ,the callback parameter is no longer optional.  

Like use in node v10.14.2
```
fs.js:137
    throw new ERR_INVALID_CALLBACK();
    ^

TypeError [ERR_INVALID_CALLBACK]: Callback must be a function
    at makeCallback (fs.js:137:11)
    at Object.unlink (fs.js:936:14)
    at ReadStream.<anonymous> (xxxxxxxxxxx\node_modules\jquery-file-upload-middleware\lib\uploadhandler.js:149:48)
    at ReadStream.emit (events.js:187:15)
    at endReadableNT (_stream_readable.js:1094:12)
    at process._tickCallback (internal/process/next_tick.js:63:19)
```

so i add some `function(){}` as the callback parameter,then the code run well.