### PR TITLE
Propagate max file size to Formidable

### DIFF
--- a/lib/uploadhandler.js
+++ b/lib/uploadhandler.js
@@ -112,7 +112,7 @@ module.exports = function (options) {
                     if (exists) {
                         fileInfo.size = file.size;
                         if (!fileInfo.validate()) {
-                            fs.unlink(file.path);
+                            fs.unlink(file.path,function(){});
                             finish();
                             return;
                         }
@@ -146,7 +146,7 @@ module.exports = function (options) {
                                     var os = fs.createWriteStream(options.uploadDir() + '/' + fileInfo.name);
                                     is.on('end', function (err) {
                                         if (!err) {
-                                            fs.unlink(file.path);
+                                            fs.unlink(file.path,function(){});
                                             generatePreviews();
                                         }
                                         finish();
@@ -163,7 +163,7 @@ module.exports = function (options) {
                 _.each(tmpFiles, function (file) {
                     var fileInfo = map[path.basename(file)];
                     self.emit('abort', fileInfo);
-                    fs.unlink(file);
+                    fs.unlink(file,function(){});
                 });
             })
             .on('error', function (e) {
@@ -189,7 +189,7 @@ module.exports = function (options) {
         }
         fs.unlink(filepath, function (ex) {
             _.each(options.imageVersions, function (value, version) {
-                fs.unlink(path.join(options.uploadDir(), version, fileName));
+                fs.unlink(path.join(options.uploadDir(), version, fileName),function(){});
             });
             self.emit('delete', fileName);
             self.callback({success: !ex});

--- a/lib/uploadhandler.js
+++ b/lib/uploadhandler.js
@@ -65,7 +65,7 @@ module.exports = function (options) {
 
     UploadHandler.prototype.post = function () {
         var self = this,
-            form = new formidable.IncomingForm(),
+            form = new formidable.IncomingForm({maxFileSize: options.maxPostSize}),
             tmpFiles = [],
             files = [],
             map = {},


### PR DESCRIPTION
A dependency Formidable now has a default upper limit of 200MB for form post requests. We pass in the limit set in the options to get around this.